### PR TITLE
job #11937 - timestamp as int omission

### DIFF
--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Domain/User Data Type/User Data Type.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Domain/User Data Type/User Data Type.xtuml
@@ -260,8 +260,6 @@ elif(param.typeName == "inst<Event>")
   return false;
 elif(param.typeName == "date")
   return false;
-elif(param.typeName == "timestamp")
-  return false;
 elif(param.typeName == "inst_ref<Timer>")
   return false;
 end if;


### PR DESCRIPTION
Check in Domain::User Data Type::isAllowedCoreType needed removed, since
timestamp is now an allowed core type.